### PR TITLE
Fixes #94 VT100 arrow keys for application mode

### DIFF
--- a/RaspberryPi/apple2driver/a2io/vt100.go
+++ b/RaspberryPi/apple2driver/a2io/vt100.go
@@ -14,6 +14,7 @@ var escapeSequence string
 var operatingSystemSequence bool
 var windowTop int
 var windowBottom = 23
+var applicationMode = false
 
 func sendCharacter(comm A2Io, b byte) {
 	if b == 0x1b {
@@ -63,11 +64,11 @@ func sendCharacter(comm A2Io, b byte) {
 			switch escapeSequence {
 			// Set/clear application mode for cursor
 			case "^[[?1h":
-				//applicationMode = true
+				applicationMode = true
 				escapeSequence = ""
 				return
 			case "^[[?1l":
-				//applicationMode = false
+				applicationMode = false
 				comm.WriteByte('T')
 				comm.WriteByte(0x00)
 				comm.WriteByte('B')
@@ -222,17 +223,32 @@ func readCharacter(comm A2Io) (string, error) {
 	b, err := comm.ReadByte()
 	var s = string(b)
 	if err == nil {
-		switch b {
-		case 0x0b: // up
-			s = "\033[A"
-		case 0x0a: // down
-			s = "\033[B"
-		case 0x15: // right
-			s = "\033[C"
-		case 0x08: // left
-			s = "\033[D"
-		case 0x0d: // return
-			s = string(byte(0x0a))
+		if applicationMode {
+			switch b {
+			case 0x0b: // up
+				s = "\033OA"
+			case 0x0a: // down
+				s = "\033OB"
+			case 0x15: // right
+				s = "\033OC"
+			case 0x08: // left
+				s = "\033OD"
+			case 0x0d: // return
+				s = string(byte(0x0a))
+			}
+		} else {
+			switch b {
+			case 0x0b: // up
+				s = "\033[A"
+			case 0x0a: // down
+				s = "\033[B"
+			case 0x15: // right
+				s = "\033[C"
+			case 0x08: // left
+				s = "\033[D"
+			case 0x0d: // return
+				s = string(byte(0x0a))
+			}
 		}
 	}
 	return s, err


### PR DESCRIPTION
In standard mode, arrows are ^[[A through ^[[B but in application mode (which vi requires), they are ^[OA through ^[OD. This is a standard VT100 arrow emulation that was missed.