### PR TITLE
Adjust AT28C64B.bin path.

### DIFF
--- a/RaspberryPiPico/CMakeLists.txt
+++ b/RaspberryPiPico/CMakeLists.txt
@@ -18,11 +18,11 @@ FetchContent_Declare(a2pico
         )
 FetchContent_MakeAvailable(a2pico)
 
-set_source_files_properties(incbin.S OBJECT_DEPENDS ../../Apple2/AT28C64B.bin)
+set_source_files_properties(incbin.S OBJECT_DEPENDS ../../RaspberryPi/driveimage/AT28C64B.bin)
 add_custom_command(
         WORKING_DIRECTORY ../../Apple2
         COMMAND ./assemble.sh 1
-        OUTPUT ../../Apple2/AT28C64B.bin
+        OUTPUT ../../RaspberryPi/driveimage/AT28C64B.bin
         VERBATIM
         )
 

--- a/RaspberryPiPico/board.c
+++ b/RaspberryPiPico/board.c
@@ -47,12 +47,12 @@ void __time_critical_func(board)(void) {
 
         if (read) {
             if (!io) {  // DEVSEL
-                switch (addr & 0x7) {
-                    case 0x3:
+                switch (addr & 0xF) {
+                    case 0xB:
                         a2pico_putdata(pio0, !multicore_fifo_rvalid() << 7 |
                                              !multicore_fifo_wready() << 6);
                         break;
-                    case 0x6:
+                    case 0xE:
                         a2pico_putdata(pio0, sio_hw->fifo_rd);
                         break;
                 }
@@ -64,12 +64,12 @@ void __time_critical_func(board)(void) {
         } else {
             uint32_t data = a2pico_getdata(pio0);
             if (!io) {  // DEVSEL
-                switch (addr & 0x7) {
-                    case 0x5:
-                        sio_hw->fifo_wr = data;
-                        break;
+                switch (addr & 0xF) {
                     case 0x7:
                         page = (data & 0x30) << 7;
+                        break;
+                    case 0xD:
+                        sio_hw->fifo_wr = data;
                         break;
                 }
             }

--- a/RaspberryPiPico/incbin.S
+++ b/RaspberryPiPico/incbin.S
@@ -3,4 +3,4 @@
 .type firmware, %object
 .balign 4
 firmware:
-.incbin "../../Apple2/AT28C64B.bin"
+.incbin "../../RaspberryPi/driveimage/AT28C64B.bin"


### PR DESCRIPTION
Please note that the AT28C64B.bin can only be rebuild reliably if it is removed from the repository.