### PR TITLE
GPIO errors on startup

### DIFF
--- a/RaspberryPi/setup.sh
+++ b/RaspberryPi/setup.sh
@@ -76,6 +76,7 @@ sudo --preserve-env=HOME --preserve-env=USER bash -c 'cat > apple2driver.service
 Description=Apple2-IO-RPi Driver (Classic edition)
 
 [Service]
+Type=idle
 ExecStart=$HOME/Apple2-IO-RPi/RaspberryPi/apple2driver/apple2driver
 StandardOutput=syslog
 StandardError=syslog

--- a/RaspberryPi/setup.sh
+++ b/RaspberryPi/setup.sh
@@ -58,6 +58,7 @@ sudo --preserve-env=HOME --preserve-env=USER bash -c 'cat > apple2driver.service
 Description=Apple2-IO-RPi Driver (Pico edition)
 
 [Service]
+Type=idle
 ExecStart=$HOME/Apple2-IO-RPi/RaspberryPi/apple2driver/apple2driver -cdc=true
 StandardOutput=syslog
 StandardError=syslog


### PR DESCRIPTION
Fixes issue that when booting the card, it sees the Pi and seems to start OK, but "Apple2-IO-RPi not found" is shown twice, then a BASIC prompt. Same error when running "-shell".